### PR TITLE
Add ALPHA tag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mailermost
+# Mailermost (ALPHA)
 
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-email-reply/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-email-reply)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-email-reply/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-email-reply)


### PR DESCRIPTION
#### Summary
Add ALPHA tag to make it clear that this is not a production ready software. 

#### Ticket Link
https://community.mattermost.com/core/pl/qppborezy7bw5fji1w8rw6wyrw

